### PR TITLE
Add support for LDAP authentication (fixes #264)

### DIFF
--- a/conjur/api/api.py
+++ b/conjur/api/api.py
@@ -43,7 +43,8 @@ class Api():
                  http_debug=False,
                  login_id: str = None,
                  ssl_verify: bool = True,
-                 url: str = None):
+                 url: str = None,
+                 service_id: str = None):
 
         self._url = url
         self._ca_bundle = ca_bundle
@@ -63,7 +64,8 @@ class Api():
 
         self._default_params = {
             'url': url,
-            'account': account
+            'account': account,
+            'service_id': service_id
         }
 
         # WARNING: ONLY FOR DEBUGGING - DO NOT CHECK IN LINES BELOW UNCOMMENTED
@@ -99,6 +101,23 @@ class Api():
 
         logging.debug("Logging in to %s...", self._url)
         self.api_key = invoke_endpoint(HttpVerb.GET, ConjurEndpoint.LOGIN,
+                                       self._default_params, auth=(login_id, password),
+                                       ssl_verify=self._ssl_verify).text
+        self.login_id = login_id
+
+        return self.api_key
+
+    def login_ldap(self, login_id: str = None, password: str = None) -> str:
+        """
+        This method uses the LDAP auth login id (username) and password
+        to retrieve an api key from the server that can be later used to
+        retrieve short-lived api tokens.
+        """
+        if not login_id or not password:
+            raise MissingRequiredParameterException("Missing parameters in login invocation!")
+
+        logging.debug("Logging in to %s...", self._url)
+        self.api_key = invoke_endpoint(HttpVerb.GET, ConjurEndpoint.LOGIN_LDAP,
                                        self._default_params, auth=(login_id, password),
                                        ssl_verify=self._ssl_verify).text
         self.login_id = login_id

--- a/conjur/api/client.py
+++ b/conjur/api/client.py
@@ -57,7 +57,8 @@ class Client():
                  login_id: str = None,
                  password: str = None,
                  ssl_verify: bool = True,
-                 url: str = None):
+                 url: str = None,
+                 service_id: str = None):
 
         if ssl_verify is False:
             util_functions.get_insecure_warning_in_debug()
@@ -72,6 +73,7 @@ class Client():
             'url': url,
             'account': account,
             'ca_bundle': ca_bundle,
+            'service_id': service_id
         }
         # Parameters from initialized client are missing and
         # will try to search for them in the conjurrc
@@ -125,7 +127,10 @@ class Client():
             self._api = Api(http_debug=http_debug,
                             ssl_verify=ssl_verify,
                             **loaded_config)
-            self._api.login(login_id, password)
+            if service_id is not None:
+                self._api.login_ldap(login_id, password)
+            else:
+                self._api.login(login_id, password)
         else:
             credential_provider, credential_location = CredentialStoreFactory.create_credential_store()
             logging.debug(f"Attempting to retrieve credentials from the '{credential_location}'...")

--- a/conjur/api/endpoints.py
+++ b/conjur/api/endpoints.py
@@ -18,6 +18,7 @@ class ConjurEndpoint(Enum):
     """
     AUTHENTICATE = "{url}/authn/{account}/{login}/authenticate"
     LOGIN = "{url}/authn/{account}/login"
+    LOGIN_LDAP = "{url}/authn-ldap/{service_id}/{account}/login"
     INFO = "{url}/info"
     POLICIES = "{url}/policies/{account}/policy/{identifier}"
     BATCH_SECRETS = "{url}/secrets"


### PR DESCRIPTION
Signed-off-by: Jérémie Dumas <jeremie.dumas@ens-lyon.org>

### What does this PR do?
- Adds support for LDAP authentication.
- Simply provide a `service_id` when creating a client to use LDAP authentication with the corresponding service_id.

### What ticket does this PR close?
Resolves #264

### Checklists

I'm not familiar enough with the testing framework to add a unit test for this. Readme/changelog can be updated if you're ok with the change.

#### Change log
- [ ] The CHANGELOG has been updated

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs