### PR TITLE
Remove irrelevant list call

### DIFF
--- a/conjur/api/api.py
+++ b/conjur/api/api.py
@@ -133,17 +133,11 @@ class Api():
             'account': self._account
         }
         params.update(self._default_params)
-        if list_constraints is not None:
-            json_response = invoke_endpoint(HttpVerb.GET, ConjurEndpoint.RESOURCES,
-                                            params,
-                                            query=list_constraints,
-                                            api_token=self.api_token,
-                                            ssl_verify=self._ssl_verify).content
-        else:
-            json_response = invoke_endpoint(HttpVerb.GET, ConjurEndpoint.RESOURCES,
-                                            params,
-                                            api_token=self.api_token,
-                                            ssl_verify=self._ssl_verify).content
+        json_response = invoke_endpoint(HttpVerb.GET, ConjurEndpoint.RESOURCES,
+                                        params,
+                                        query=list_constraints,
+                                        api_token=self.api_token,
+                                        ssl_verify=self._ssl_verify).content
 
         resources = json.loads(json_response.decode('utf-8'))
 
@@ -152,7 +146,6 @@ class Api():
         if list_constraints is not None and 'inspect' not in list_constraints:
             # For each element (resource) in the resources sequence, we extract the resource id
             resource_list = map(lambda resource: resource['id'], resources)
-            # TODO: Understand why list and not dict
             return list(resource_list)
 
         # To see the full resources response see


### PR DESCRIPTION
### What does this PR do?

Previously, we had an 'if/else' statement where the 'else' was never being reached. It was originally added to differentiate when the request had constraints and when it didn't. Being that in the end, it doesn't make a difference and requests are correctly invoked, this should be removed as it is never being reached.

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation