### PR TITLE
Remove sdk content from readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Removed
+- `SDK` with all it contents was removed and now maintained under https://github.com/cyberark/conjur-api-python
+
 ## [7.1.0] - 2021-12-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Removed
-- `SDK` with all it contents was removed and now maintained under https://github.com/cyberark/conjur-api-python
+- `SDK` with all it contents was removed and is now maintained in the https://github.com/cyberark/conjur-api-python repository
 
 ## [7.1.0] - 2021-12-22
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # cyberark-conjur-cli
 
-This repository includes both the self-contained Conjur CLI (`conjur`) and the Python3-based SDK for
+This repository includes self-contained Conjur CLI (`conjur`) for
 accessing the Conjur API to manage Conjur resources.
+
+Note: Conjur python SDK was removed from this repo and is now maintained under 
+https://github.com/cyberark/conjur-api-python repository
 
 [![Test Coverage](https://api.codeclimate.com/v1/badges/d90d69a3942120b36785/test_coverage)](https://codeclimate.com/github/cyberark/cyberark-conjur-cli/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/d90d69a3942120b36785/maintainability)](https://codeclimate.com/github/cyberark/cyberark-conjur-cli/maintainability)
 
@@ -16,14 +19,6 @@ accessing the Conjur API to manage Conjur resources.
 The Conjur CLI is a **Certified** level project. It's been reviewed by CyberArk to verify that it works securely
 with CyberArk Conjur Enterprise (previously known as Dynamic Access Provider). In addition, CyberArk offers Enterprise-level
 support for these features. For more detailed information on our certification levels,
-see [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community).
-
-### Conjur Python SDK
-
-![](https://img.shields.io/badge/Certification%20Level-Community-28A745?link=https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md)
-
-The Conjur Python SDK is a **Community** level project. It's a community-contributed project that 
-**is not reviewed or supported by CyberArk**. For more detailed information on our certification levels,
 see [our community guidelines](https://github.com/cyberark/community/blob/main/Conjur/conventions/certification-levels.md#community).
 
 ### Using cyberark-conjur-cli with Conjur Open Source
@@ -50,258 +45,16 @@ questions, please contact us on [Discourse](https://discuss.cyberarkcommons.org/
 
 ### Installation
 
-#### Install the Conjur CLI
-
 To access the latest release of the Conjur CLI, go to
 our [release](https://github.com/cyberark/cyberark-conjur-cli/releases)
 page. For instructions on how to set up and configure the CLI, see
 our [official documentation](https://docs.conjur.org/Latest/en/Content/Developer/CLI/cli-lp.htm).
 
-#### Install the SDK
-
-The SDK can be installed via PyPI. Note that the SDK is a **Community** level project, meaning that the SDK is subject to
-modifications that may result in breaking changes.
-
-To avoid unanticipated breaking changes, make sure that you stay up to date on our latest releases and always review the
-project's [CHANGELOG.md](CHANGELOG.md).
-
-```
-pip3 install conjur
-
-conjur --help
-```
-
-Alternatively, you can install the library from the source. Note that this will install the latest work from the cloned
-source and not necessarily an official release.
-
-Clone the project and run:
-
-```
-pip3 install 
-```
-
 ## Usage
-
-### CLI
 
 For more information on how to set up, configure, and start using the Conjur CLI, see
 our [official documentation](https://docs.conjur.org/Latest/en/Content/Developer/CLI/cli-lp.htm).
 
-### SDK
-
-To start using the SDK in your applications, create a Client instance and then invoke the API on it.
-
-#### Imports
-
-Import the relevant modules
-
-```
-from conjur.api.models import SslVerificationMode
-from conjur.data_object import CredentialsData, ConjurrcData
-from conjur.logic.credential_provider import CredentialStoreFactory
-from conjur.api.client import Client
-```
-
-#### Step 1. Define connection parameters
-
-To log in to Conjur, define the following parameters, for example:
-
-```
-conjur_url = "https://conjur-myorg.example.com"
-account = "my_account"
-username = "user1"
-api_key = "a1s2d3f4gg55h432hhky4"
-ssl_verification_mode = SslVerificationMode.TRUST_STORE
-```
-ssl_verification_mode is an enum that states which certificate verification technique to use when making the API 
-request. 
-
-Use one of the following:
-
-| Enum value | Description                                                  |
-| ---------------- | ------------------------------------------------------------ |
-| `TRUST_STORE`             | The client is using the system's trusted CA as set by the machine admin |
-| `CA_BUNDLE`             | The client uses ca_bundle file to validate server certificate |
-| `SELF_SIGN`             | The client uses the self signed rootCA file to validate server certificate|
-| `INSECURE`             | (**NOT RECOMMENDED!**) The client does not validate the server certificate |
-* Note: for `CA_BUNDLE` and `SELF_SIGN` modes, the path to the required file is provided in the `ConjurrcData`,`cert_file` 
-  argument 
-
-#### Step 2. Define ConjurrcData
-
-ConjurrcData is a data class containing all the 'non-credential' connection details.
-```
-conjurrc_data = ConjurrcData(conjur_url=conjur_url,account=account,cert_file = None)
-```
-
-* conjur_url - URL of the Conjur server
-* account - the organizational Conjur account name
-* cert_file - a path to the Conjur rootCA file. This is required if you are initializing the client in `SslVerificationMode.SELF_SIGN`
-  or `SslVerificationMode.CA_BUNDLE` mode
-
-#### Step 3. Storing credentials
-
-The client retrieves credentials from a credential store called `CredentialStore` which inherits from `CredentialsStoreInterface`. This
-approach enables storing the credentials in a safe location, and providing the credentials to the client on demand.
-
-The SDK provides the following implementations of `CredentialsStoreInterface`:
--  `KeystoreCredentialsProvider` which saves credentials to the system's credential store (macOS keychain for example)
--  `FileCredentialsProvider` which saves the credentials into `.netrc` file, in plaintext.
-
-
-We provide the`CredentialStoreFactory` which creates such credential stores.
-
-By default, the `CredentialStoreFactory` favors creating a `KeystoreCredentialsProvider`. If the SDK cannot access the 
-operating system's credential store, then `CredentialStoreFactory` will create `FileCredentialsProvider` instead.
-
-If credentials are written to the `.netrc`, we strongly recommend deleting those credentials when not using the
-SDK. The `.netrc` file is located in the user's home directory, for example: `/Users/my_username` in macOS 
-or `C:\Users\my_username` in Windows
-
-The `.netrc` file or (`_netrc` for Windows environments) contains credentials needed to log in to the Conjur server
-and should consist of 'machine', 'login', and 'password'.
-
-```
-# .netrc / _netrc
-machine https://conjur-myorg.example.com
-login admin
-password 1234....
-```
-
-Note: If you choose to create this file yourself, make sure to follow least privilege rule, allowing only the user who has
-created the file to have read/write permissions on it (`chmod 600 .netrc`).
-
-
-Example of usage:
-
-- Create credential store:
-  ```
-  credentials_store = CredentialStoreFactory.create_credential_store()
-  ```
-
-- Store credentials inside the store
-  ```
-  credentials = CredentialsData(login=username, password=api_key, machine=conjur_url)
-  credentials_store.save(credentials)
-  del credentials # After being saved, it's consider best practice to delete credentials from memory after usage
-  ```
-  - Note: This step is needed only once! Credential stores provided by the SDK are meant to be persistent and can 
-    be used multiple times, even if your app crashed or started and stopped multiple times.
-    
-#### Step 4. Create the client and use it
-
-Now that you have created `conjurrc_data` and `credentials_provider`,
-you can create your client.
-
-```
-client = Client(conjurrc_data, credentials_provider=credentials_provider, ssl_verification_mode=ssl_verification_mode)
-```
-
-After you create the client, you can start using it. 
-
-Example of usage:
-
-```
-client.list() # get list of all Conjur resources that the user is authorized to read`
-```
-
-## Supported client methods
-
-#### `get(variable_id)`
-
-Gets a variable value based on its ID. A variable is binary data that should be decoded to your system's encoding. For
-example:
-`get(variable_id).decode('utf-8')`.
-
-#### `get_many(variable_id[,variable_id...])`
-
-Gets multiple variable values based on their IDs. Variables are returned in a dictionary that maps the variable name to
-its value.
-
-#### `set(variable_id, value)`
-
-Sets a variable to a specific value based on its ID.
-
-Note: Policy to create the variable must have already been loaded, otherwise you will get a 404 error during invocation.
-
-#### `load_policy_file(policy_name, policy_file)`
-
-Applies a file-based YAML to a named policy. This method only supports additive changes. Result is a dictionary object
-constructed from the returned JSON data.
-
-#### `replace_policy_file(policy_name, policy_file)`
-
-Replaces a named policy with one from the provided file. This is usually a destructive invocation. Result is a
-dictionary object constructed from the returned JSON data.
-
-#### `update_policy_file(policy_name, policy_file)`
-
-Modifies an existing Conjur policy. Data may be explicitly deleted using the `!delete`, `!revoke`, and `!deny`
-statements. Unlike
-"replace" mode, no data is ever implicitly deleted. Result is a dictionary object constructed from the returned JSON
-data.
-
-#### `list(list_constraints)`
-
-Returns a list of all available resources for the current account.
-
-The 'list constraints' parameter is optional and should be provided as a dictionary.
-
-For example: `client.list({'kind': 'user', 'inspect': True})`
-
-| List constraints | Explanation                                                  |
-| ---------------- | ------------------------------------------------------------ |
-| kind             | Filter resources by specified kind (user, host, layer, group, policy, variable, or webservice) |
-| limit            | Limit list of resources to specified number                  |
-| offset           | Skip specified number of resources                           |
-| role             | Retrieve list of resources that specified role is entitled to see (must specify role's full ID) |
-| search           | Search for resources based on specified query                |
-| inspect          | List the metadata for resources                              |
-
-#### `def list_permitted_roles(list_permitted_roles_data: ListPermittedRolesData)`
-
-Lists the roles which have the named permission on a resource.
-
-#### `def list_members_of_role(data: ListMembersOfData)`
-
-Lists the resources which are members of the given resource.
-
-#### `def create_token(create_token_data: CreateTokenData)`
-
-Creates Host Factory tokens for creating hosts
-
-#### `def create_host(create_host_data: CreateHostData)`
-
-Uses Host Factory token to create host
-
-#### `def revoke_token(token: str)`
-
-Revokes the given Host Factory token
-
-#### `rotate_other_api_key(resource: Resource)`
-
-Rotates another entity's API key and returns it as a string.
-
-Note: resource is of type Resource which should have `type` (user / host) and
-`name` attributes.
-
-#### `rotate_personal_api_key(logged_in_user, current_password)`
-
-Rotates the personal API key of the logged-in user and returns it as a string.
-
-#### `change_personal_password(logged_in_user, current_password, new_password)`
-
-Updates the current, logged-in user's password with the password parameter provided.
-
-Note: the new password must meet the Conjur password complexity constraints. It must contain at least 12 characters: 2
-uppercase, 2 lowercase, 1 digit, 1 special character.
-
-#### `whoami()`
-
-_Note: This method requires Conjur v1.9+_
-
-Returns a Python dictionary of information about the client making an API request (such as its IP address, user,
-account, token expiration date, etc).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository includes self-contained Conjur CLI (`conjur`) for
 accessing the Conjur API to manage Conjur resources.
 
-Note: Conjur python SDK was removed from this repo and is now maintained under 
+Note: The Conjur Python SDK was removed from this repo and is now maintained in the 
 https://github.com/cyberark/conjur-api-python repository
 
 [![Test Coverage](https://api.codeclimate.com/v1/badges/d90d69a3942120b36785/test_coverage)](https://codeclimate.com/github/cyberark/cyberark-conjur-cli/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/d90d69a3942120b36785/maintainability)](https://codeclimate.com/github/cyberark/cyberark-conjur-cli/maintainability)


### PR DESCRIPTION
added link to SDK repo

### Desired Outcome

SDK is now leaving under a different repo.
we should remove it from our docs and add reference to it in the README.md file

### Implemented Changes

- Removed sdk content from readme
- Added link to SDK repo
- Updated changelog

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
