### PR TITLE
Revert conjurrc key names to match Ruby CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [7.2.0] - 2022-06-15
+## [7.2.0] - 2022-07-11
+
+### Changed
+- Revert conjurrc key names to match Ruby CLI.
+  [cyberark/cyberark-conjur-cli#413](https://github.com/cyberark/cyberark-conjur-cli/pull/413)
 
 ### Added
 - Support authn-ldap

--- a/conjur/config.py
+++ b/conjur/config.py
@@ -31,8 +31,8 @@ class Config():
     # We intentionally remap some fields to friendlier names
     # Conjurrc field / Config name / Mandatory
     FIELDS = [
-        ('conjur_account', 'account', True),
-        ('conjur_url', 'url', True),
+        ('account', 'account', True),
+        ('appliance_url', 'url', True),
         ('cert_file', 'ca_bundle', True),
         ('authn_type', 'authn_type', False),
     ]

--- a/conjur/errors_messages.py
+++ b/conjur/errors_messages.py
@@ -23,8 +23,8 @@ FETCH_CREDENTIALS_FAILURE_MESSAGE = "Failed to fetch credentials. Log in again a
 
 FETCH_CONFIGURATION_FAILURE_MESSAGE = "The conjurrc configuration file is either invalid or missing parameters. "\
                                       "Reinitialize the client and make sure that the conjurrc contains "\
-                                      "'conjur_account', 'conjur_url', and 'cert_file'."
+                                      "'account', 'appliance_url', and 'cert_file'."
 
 CONFIGURATION_MISSING_FAILURE_MESSAGE = "The conjurrc configuration file content is empty. Reinitialize "\
                                         "the client and make sure that the conjurrc contains "\
-                                        "'conjur_account', 'conjur_url', and 'cert_file'."
+                                        "'account', 'appliance_url', and 'cert_file'."

--- a/test/test_config/bad_cert_conjurrc
+++ b/test/test_config/bad_cert_conjurrc
@@ -1,4 +1,4 @@
 ---
-conjur_account: dev
-conjur_url: https://conjur-https
+account: dev
+appliance_url: https://conjur-https
 cert_file: ./test/test_config/https/nginx.conf

--- a/test/test_config/good_conjurrc
+++ b/test/test_config/good_conjurrc
@@ -1,4 +1,4 @@
 ---
-conjur_account: accountname
-conjur_url: https://someurl/somepath
+account: accountname
+appliance_url: https://someurl/somepath
 cert_file: "/cert/file/location"

--- a/test/test_config/incorrect_format_conjurrc
+++ b/test/test_config/incorrect_format_conjurrc
@@ -1,6 +1,6 @@
 ---
 account: accountname
 plugins: []
-appliance_url: https://someurl/somepath
+url: https://someurl/somepath
 cert_file: "/cert/file/location"
 version: 4

--- a/test/test_config/missing_url_conjurrc
+++ b/test/test_config/missing_url_conjurrc
@@ -1,3 +1,3 @@
 ---
-conjur_account: accountname
+account: accountname
 cert_file: "/cert/file/location"

--- a/test/test_config/no_cert_conjurrc
+++ b/test/test_config/no_cert_conjurrc
@@ -1,4 +1,4 @@
 ---
-conjur_account: dev
-conjur_url: https://conjur-https
+account: dev
+appliance_url: https://conjur-https
 cert_file: ''

--- a/test/test_config/no_cert_localhost_conjurrc
+++ b/test/test_config/no_cert_localhost_conjurrc
@@ -1,4 +1,4 @@
 ---
-conjur_account: dev
-conjur_url: https://localhost
+account: dev
+appliance_url: https://localhost
 cert_file: ''

--- a/test/test_integration_oss.py
+++ b/test/test_integration_oss.py
@@ -55,5 +55,5 @@ class CliIntegrationTestOSS(IntegrationTestCaseBase):
             with open(f"{DEFAULT_CONFIG_FILE}", 'r') as conjurrc:
                 lines = conjurrc.readlines()
                 assert "---" in lines[0]
-                assert "conjur_account: someotheraccount" in lines[3]
-                assert f"conjur_url: {self.client_params.hostname}" in lines[4]
+                assert "account: someotheraccount" in lines[1]
+                assert f"appliance_url: {self.client_params.hostname}" in lines[2]

--- a/test/test_unit_conjurrc_data.py
+++ b/test/test_unit_conjurrc_data.py
@@ -12,9 +12,24 @@ class ConjurrcDataTest(unittest.TestCase):
         expected_rep_obj = {'conjur_url': 'https://someurl', 'conjur_account': 'someaccount', 'cert_file': "/some/cert/path", 'authn_type': AuthnTypes.AUTHN, 'service_id': None}
         self.assertEquals(str(expected_rep_obj), rep_obj)
 
-    input_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem'}
+    input_dict = {'appliance_url': 'https://someurl', 'account': 'someacc', 'cert_file': '/some/path/to/pem'}
     @patch('yaml.load', return_value=input_dict)
     def test_conjurrc_object_is_filled_correctly(self, mock_yaml_load):
+        read_data = \
+"""
+---
+account: someacc
+appliance_url: https://someurl
+cert_file: /some/path/to/pem
+"""
+        expected_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem', 'authn_type': AuthnTypes.AUTHN, 'service_id': None}
+        with patch("builtins.open", mock_open(read_data=read_data)):
+            mock_conjurrc_data = ConjurrcData.load_from_file()
+            self.assertEquals(mock_conjurrc_data.__dict__, expected_dict)
+
+    input_dict = {'conjur_url': 'https://someurl', 'conjur_account': 'someacc', 'cert_file': '/some/path/to/pem'}
+    @patch('yaml.load', return_value=input_dict)
+    def test_conjurrc_accepts_alternative_keynames(self, mock_yaml_load):
         read_data = \
 """
 ---
@@ -37,8 +52,8 @@ cert_file: /some/path/to/pem
         read_data = \
 """
 ---
-conjur_account: someacc
-conjur_url: https://someurl
+account: someacc
+appliance_url: https://someurl
 cert_file: /some/path/to/pem
 authn_type: abcd
 """

--- a/test/test_unit_init_logic.py
+++ b/test/test_unit_init_logic.py
@@ -18,8 +18,8 @@ MIIDOD...
 
 EXPECTED_CONFIG = \
     '''---
-    conjur_account: someaccount
-    conjur_url: https://someurl
+    account: someaccount
+    appliance_url: https://someurl
     cert_file: /path/to/conjur-someaccount.pem
     '''
 
@@ -88,7 +88,7 @@ class InitLogicTest(unittest.TestCase):
                 with open('path/to/conjurrc', 'r') as conjurrc:
                     lines = conjurrc.readlines()
                     self.assertEquals(lines[0].strip(), "---")
-                    self.assertEquals(lines[1].strip(), "conjur_account: someaccount")
+                    self.assertEquals(lines[1].strip(), "account: someaccount")
                     self.assertEquals(lines[3].strip(),
                                       "cert_file: /path/to/conjur-someaccount.pem")
 

--- a/test/util/models/configfile.py
+++ b/test/util/models/configfile.py
@@ -10,8 +10,8 @@ class ConfigFile:
 
     def __str__(self):
         str = "---\n"
-        str += f"conjur_account: {self.account}\n"
-        str += f"conjur_url: {self.conjur_url}\n"
+        str += f"account: {self.account}\n"
+        str += f"appliance_url: {self.conjur_url}\n"
         str += f"cert_file: {self.cert_file}\n"
         return str
 
@@ -25,9 +25,9 @@ class ConfigFile:
         ret = ConfigFile()
         with open(file_path, 'r') as f:
             for line in f.readlines():
-                if line.strip().startswith('conjur_account'):
+                if line.strip().startswith('account'):
                     ret.account = "".join(line.split(":")[1:]).strip()
-                if line.strip().startswith('conjur_url'):
+                if line.strip().startswith('appliance_url'):
                     ret.conjur_url = "".join(line.split(":")[1:]).strip()
                 if line.strip().startswith('cert_file'):
                     ret.cert_file = "".join(line.split(":")[1:]).strip()

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -62,10 +62,10 @@ def verify_conjurrc_contents(account, hostname, cert, authn_type='authn', servic
     with open(f"{DEFAULT_CONFIG_FILE}", 'r') as conjurrc:
         lines = conjurrc.readlines()
         assert "---" in lines[0]
-        assert f"authn_type: {authn_type}" in lines[1], lines[1]
-        assert f"cert_file: {cert}" in lines[2], lines[2]
-        assert f"conjur_account: {account}" in lines[3], lines[3]
-        assert f"conjur_url: {hostname}" in lines[4], lines[4]
+        assert f"account: {account}" in lines[1], lines[1]
+        assert f"appliance_url: {hostname}" in lines[2], lines[2]
+        assert f"authn_type: {authn_type}" in lines[3], lines[3]
+        assert f"cert_file: {cert}" in lines[4], lines[4]
         if service_id:
             assert f"service_id: {service_id}" in lines[5], lines[5]
 


### PR DESCRIPTION
### Desired Outcome

Update the Python CLI to use the older names for the keys in the conjurrc file. This means changing conjur_account => account and conjur_url => appliance_url.

### Implemented Changes

When reading or writing .conjurrc:

- `conjur_account` is now `account`
- `conjur_url` is now `appliance_url`

For now we are still supporting the old keys when *reading* the conjurrc in order not to break existing installations of the 7.x CLI. This is deprecated and will be removed in a future release.

This fixes incompatibility between this Python CLI and the previous
Ruby/Docker based CLI, as well as summon-conjur.

The variable names remain the same. Only the key names are changed.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-22955](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22955)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
