### PR TITLE
Add "show" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [7.2.0] - 2022-07-11
 
-### Changed
-- Revert conjurrc key names to match Ruby CLI.
-  [cyberark/cyberark-conjur-cli#413](https://github.com/cyberark/cyberark-conjur-cli/pull/413)
-
 ### Added
+- Add "show" command
+  [cyberark/cyberark-conjur-cli#416](https://github.com/cyberark/cyberark-conjur-cli/pull/416)
 - Support authn-ldap
   [cyberark/cyberark-conjur-cli#411](https://github.com/cyberark/cyberark-conjur-cli/pull/411)
 - Add netrc credential storage mode as `init` option via `--force-netrc`
   [cyberark/cyberark-conjur-cli#414](https://github.com/cyberark/cyberark-conjur-cli/pull/414)
+
+### Changed
+- Revert conjurrc key names to match Ruby CLI.
+  [cyberark/cyberark-conjur-cli#413](https://github.com/cyberark/cyberark-conjur-cli/pull/413)
 
 ### Fixed
 - Corrected the `tar` command in the RHEL release steps.

--- a/conjur/argument_parser/_show_parser.py
+++ b/conjur/argument_parser/_show_parser.py
@@ -1,0 +1,53 @@
+"""
+Module For the ShowParser
+"""
+
+import argparse
+from conjur.argument_parser.parser_utils import command_description, command_epilog, formatter, title_formatter
+from conjur.wrapper.argparse_wrapper import ArgparseWrapper
+
+# pylint: disable=too-few-public-methods
+class ShowParser:
+    """Partial class of the ArgParseBuilder.
+    This class add the Show subparser to the ArgParseBuilder parser."""
+
+    def __init__(self):
+        self.resource_subparsers = None # here to reduce warnings on resource_subparsers not exist
+        raise NotImplementedError("this is partial class of ArgParseBuilder")
+
+    def add_show_parser(self):
+        """
+        Method adds show parser functionality to parser
+        """
+        show_subparser = self._create_show_parser()
+        self._add_show_options(show_subparser)
+        return self
+
+    def _create_show_parser(self):
+        show_name = 'show - Show an object'
+        show_usage = 'conjur [global options] show [args]'
+
+        show_subparser = self.resource_subparsers \
+            .add_parser('show',
+                        help='Shows an object',
+                        description=command_description(show_name,
+                                                        show_usage),
+                        epilog=command_epilog(
+                            'conjur show -i variable:somevariable\t'
+                            'Shows metadata about the variable somevariable\n'
+                        ),
+                        usage=argparse.SUPPRESS,
+                        add_help=False,
+                        formatter_class=formatter)
+        return show_subparser
+
+    @staticmethod
+    def _add_show_options(show_subparser: ArgparseWrapper):
+        show_options = show_subparser.add_argument_group(title=title_formatter("Options"))
+
+        show_options.add_argument('-i', '--id', dest='identifier', metavar='VALUE',
+                                          help='Provide variable identifier',
+                                          required=True)
+
+        show_options.add_argument('-h', '--help', action='help',
+                                    help='Display help screen and exit')

--- a/conjur/argument_parser/argparse_builder.py
+++ b/conjur/argument_parser/argparse_builder.py
@@ -12,6 +12,7 @@ from conjur.argument_parser._logout_parser import LogoutParser
 from conjur.argument_parser._policy_parser import PolicyParser
 from conjur.argument_parser._host_parser import HostParser
 from conjur.argument_parser._list_parser import ListParser
+from conjur.argument_parser._show_parser import ShowParser
 from conjur.argument_parser._screen_options_parser import ScreenOptionsParser
 from conjur.argument_parser._user_parser import UserParser
 from conjur.argument_parser._variable_parser import VariableParser
@@ -26,6 +27,7 @@ class ArgParseBuilder(InitParser,
                       PolicyParser,
                       HostParser,
                       ListParser,
+                      ShowParser,
                       UserParser,
                       VariableParser,
                       WhoamiParser,

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -61,6 +61,7 @@ class Cli:
             .add_init_parser() \
             .add_logout_parser() \
             .add_list_parser() \
+            .add_show_parser() \
             .add_host_parser() \
             .add_policy_parser() \
             .add_user_parser() \
@@ -155,6 +156,9 @@ class Cli:
         if resource == 'list':
             cli_actions.handle_list_logic(args, client)
 
+        elif resource == 'show':
+            cli_actions.handle_show_logic(args, client)
+
         elif resource == 'whoami':
             result = client.whoami()
             print(json.dumps(result, indent=4))
@@ -201,7 +205,7 @@ class Cli:
             sys.exit(0)
 
         # Check whether we are running a command with required additional arguments/options
-        if args.resource not in ['list', 'whoami', 'init', 'login', 'logout']:
+        if args.resource not in ['list', 'show', 'whoami', 'init', 'login', 'logout']:
             if 'action' not in args or not args.action:
                 parser.print_help()
                 sys.exit(0)

--- a/conjur/cli_actions.py
+++ b/conjur/cli_actions.py
@@ -16,6 +16,7 @@ from conjur_api.models import CreateHostData, CreateTokenData, ListMembersOfData
 # Internal
 # pylint: disable=too-many-arguments
 from conjur.controller.hostfactory_controller import HostFactoryController
+from conjur.controller.show_controller import ShowController
 
 from conjur.errors import ConflictingParametersException, FileNotFoundException, \
     InvalidFilePermissionsException, MissingRequiredParameterException
@@ -27,6 +28,7 @@ from conjur.logic import InitLogic, LoginLogic, LogoutLogic, ListLogic, Variable
     PolicyLogic, UserLogic
 from conjur.data_object import ConjurrcData, UserInputData, HostResourceData, ListData, VariableData, \
     PolicyData
+from conjur.logic.show_logic import ShowLogic
 from conjur.util.ssl_utils import SSLClient
 from conjur.util import init_utils, util_functions
 from conjur.constants import DEFAULT_NETRC_FILE
@@ -143,6 +145,15 @@ def handle_list_logic(args: list = None, client=None):
                              search=args.search, limit=args.limit,
                              offset=args.offset, role=args.role)
         list_controller.load(list_data)
+
+
+def handle_show_logic(args: list = None, client=None):
+    """
+    Method wraps the show call logic
+    """
+    show_logic = ShowLogic(client)
+    show_controller = ShowController(show_logic=show_logic)
+    show_controller.load(args.identifier)
 
 
 def handle_hostfactory_logic(args: list = None, client=None):

--- a/conjur/controller/list_controller.py
+++ b/conjur/controller/list_controller.py
@@ -6,13 +6,11 @@ ListController module
 This module is the controller that facilitates all list actions
 required to successfully execute the LIST command
 """
-# Builtins
-import json
-import sys
 
 from conjur_api.models import ListMembersOfData, ListPermittedRolesData
 from conjur.logic.list_logic import ListLogic
 from conjur.data_object.list_data import ListData
+from conjur.util import util_functions
 
 
 class ListController:
@@ -30,25 +28,18 @@ class ListController:
         Method that facilitates all method calls in this class
         """
         result = self.list_logic.list(list_data)
-        self.print_json_result(result)
+        util_functions.print_json_result(result)
 
     def get_permitted_roles(self, list_permitted_roles_data: ListPermittedRolesData):
         """
         Get all permitted roles according to given data
         """
         result = self.list_logic.get_permitted_roles(list_permitted_roles_data)
-        self.print_json_result(result)
+        util_functions.print_json_result(result)
 
     def get_role_members(self, list_role_members_data: ListMembersOfData):
         """
         List members within a role
         """
         result = self.list_logic.get_members_of(list_role_members_data)
-        self.print_json_result(result)
-
-    @classmethod
-    def print_json_result(cls, result: list):
-        """
-        Method to print the JSON of the returned result
-        """
-        sys.stdout.write(f"{json.dumps(result, indent=4)}\n")
+        util_functions.print_json_result(result)

--- a/conjur/controller/show_controller.py
+++ b/conjur/controller/show_controller.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+"""
+ShowController module
+
+This module is the controller that facilitates all show actions
+required to successfully execute the SHOW command
+"""
+
+from conjur_api.errors.errors import HttpStatusError
+from conjur.logic.show_logic import ShowLogic
+from conjur.resource import Resource
+from conjur.util import util_functions
+
+# pylint: disable=too-few-public-methods
+class ShowController:
+    """
+    ShowController
+
+    This class represents the Presentation Layer for the SHOW command
+    """
+
+    def __init__(self, show_logic: ShowLogic):
+        self.show_logic = show_logic
+
+    def load(self, resource_id: str):
+        """
+        Method that facilitates all method calls in this class
+        """
+        resource = Resource.from_full_id(resource_id)
+        try:
+            result = self.show_logic.show(resource.kind, resource.identifier)
+            util_functions.print_json_result(result)
+        except HttpStatusError as http_error:
+            raise HttpStatusError(status=http_error.status,
+                                  message=f"{http_error}. Error: {http_error.response}",
+                                  response=http_error.response) from http_error

--- a/conjur/logic/show_logic.py
+++ b/conjur/logic/show_logic.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+"""
+ShowLogic module
+
+This module is the business logic for executing the show command
+"""
+
+import json
+
+# pylint: disable=too-few-public-methods
+class ShowLogic:
+    """
+    ShowLogic
+
+    This class holds the business logic for displaying individual resources.
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+    def show(self, kind: str, resource_id: str) -> json:
+        """
+        Method for calling get_resource from the client service
+        """
+        return self.client.get_resource(kind, resource_id)

--- a/conjur/util/util_functions.py
+++ b/conjur/util/util_functions.py
@@ -8,9 +8,11 @@ This module holds the common logic across the codebase
 
 # Builtins
 import http
+import json
 import logging
 import platform
 import os
+import sys
 
 # SDK
 from conjur_api.errors.errors import HttpError
@@ -139,3 +141,9 @@ def get_netrc_path_from_conjurrc(conjur_data: ConjurrcData = None) -> str:
     if hasattr(conjur_data, "netrc_path") and conjur_data.netrc_path is not None:
         return conjur_data.netrc_path
     return None
+
+def print_json_result(result):
+    """
+    Method to print the JSON of the returned result
+    """
+    sys.stdout.write(f"{json.dumps(result, indent=4)}\n")

--- a/test/test_config/show_policy.yml
+++ b/test/test_config/show_policy.yml
@@ -1,0 +1,6 @@
+- !layer somelayer
+- !group somegroup
+- !host anotherhost
+- !user someuser
+- !variable one/password
+- !webservice somewebservice

--- a/test/test_integration_show.py
+++ b/test/test_integration_show.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+
+"""
+CLI Show Integration tests
+This test file handles the main test flows for the show command
+"""
+from contextlib import redirect_stderr
+import io
+import os
+from unittest.mock import patch
+
+from conjur.constants import LOGIN_IS_REQUIRED
+from test.util.test_infrastructure import integration_test
+from test.util.test_runners.integration_test_case import IntegrationTestCaseBase
+from test.util import test_helpers as utils
+
+
+# Not coverage tested since integration tests don't run in
+# the same build step
+class CliIntegrationTestShow(IntegrationTestCaseBase):  # pragma: no cover
+    capture_stream = io.StringIO()
+    defined_variable_id='one/password'
+    expected_output = '"id": "dev:variable:one/password",\n    "owner": "dev:user:admin",\n    "policy": "dev:policy:root",\n    "permissions": []'
+
+    def __init__(self, testname, client_params=None, environment_params=None):
+        super(CliIntegrationTestShow, self).__init__(testname, client_params, environment_params)
+
+    # *************** HELPERS ***************
+
+    def setUp(self):
+        self.setup_cli_params({})
+        # Used to configure the CLI and login to run tests
+        utils.setup_cli(self)
+        return self.invoke_cli(self.cli_auth_params,
+                               ['policy', 'replace', '-b', 'root', '-f', self.environment.path_provider.get_policy_path("show")])
+
+    # *************** TESTS ***************
+
+    @integration_test()
+    def test_show_get_insecure_prints_warning_in_log(self):
+        with self.assertLogs('', level='DEBUG') as mock_log:
+            self.invoke_cli(self.cli_auth_params,
+                                     ['--insecure', 'show', '-i', f'variable:{self.defined_variable_id}'])
+            self.assertIn("Warning: Running the command with '--insecure' makes your system vulnerable to security attacks",
+                          str(mock_log.output))
+
+    @integration_test()
+    def test_show_without_id_returns_help(self):
+        with redirect_stderr(self.capture_stream):
+            self.invoke_cli(self.cli_auth_params,
+                            ['show'], exit_code=1)
+        self.assertIn("Error the following arguments are required:", self.capture_stream.getvalue())
+
+    @integration_test(True)
+    def test_show_short_with_help_returns_show_help(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-h'])
+        self.assertIn("Name:\n  show", output)
+
+    @integration_test(True)
+    def test_show_long_with_help_returns_show_help(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '--help'])
+        self.assertIn("Name:\n  show", output)
+
+    @integration_test(True)
+    def test_show_long_resource_id_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', f'--id=variable:{self.defined_variable_id}'])
+        self.assertIn(self.expected_output, output)
+
+    @integration_test(True)
+    def test_show_short_resource_id_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', f'variable:{self.defined_variable_id}'])
+        self.assertIn(self.expected_output, output)
+
+    @integration_test(True)
+    def test_show_resource_id_with_account_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', f'dev:variable:{self.defined_variable_id}'])
+        self.assertIn(self.expected_output, output)
+
+    @integration_test(True)
+    def test_show_policy_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'dev:policy:root'])
+        self.assertIn('"id": "dev:policy:root"', output)
+
+    @integration_test(True)
+    def test_show_user_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'dev:user:someuser'])
+        self.assertIn('"id": "dev:user:someuser"', output)
+
+    @integration_test(True)
+    def test_show_layer_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'dev:layer:somelayer'])
+        self.assertIn('"id": "dev:layer:somelayer"', output)
+
+    @integration_test(True)
+    def test_show_group_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'dev:group:somegroup'])
+        self.assertIn('"id": "dev:group:somegroup"', output)
+
+    @integration_test(True)
+    def test_show_host_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'dev:host:anotherhost'])
+        self.assertIn('"id": "dev:host:anotherhost"', output)
+
+    @integration_test(True)
+    def test_show_webservice_returns_resource(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'dev:webservice:somewebservice'])
+        self.assertIn('"id": "dev:webservice:somewebservice"', output)
+
+    @integration_test(True)
+    def test_unknown_resource_raises_not_found_error(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['show', '-i', 'variable:unknown'], exit_code=1)
+        self.assertIn("404 (Not Found) for url:", output)
+
+    '''
+    Validates that when the user isn't logged in and makes a request,
+    they are prompted to login first and then the command is executed
+    '''
+    @integration_test()
+    @patch('builtins.input', return_value='admin')
+    def test_show_without_user_logged_in_prompts_login_and_performs_show(self, mock_input):
+        # TEST_ENV is set to False so we will purposely be prompted to login
+        os.environ['TEST_ENV'] = 'False'
+        try:
+            utils.delete_credentials()
+        except OSError:
+            pass
+
+        with patch('getpass.getpass', return_value=self.client_params.env_api_key):
+            output = self.invoke_cli(self.cli_auth_params,
+                                     ['show', '-i', f'variable:{self.defined_variable_id}'])
+
+            self.assertIn(LOGIN_IS_REQUIRED, output)
+            self.assertIn("Successfully logged in to Conjur", output)
+            self.assertIn(self.expected_output, output)
+        os.environ['TEST_ENV'] = 'True'

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -189,6 +189,14 @@ Copyright (c) {time.strftime("%Y")} CyberArk Software Ltd. All rights reserved.
     def test_cli_resource_listing_outputs_formatted_json(self, cli_invocation, output, client):
         self.assertEquals('[\n    "some_id1",\n    "some_id2"\n]\n', output)
 
+    @cli_test(["show", "-i", "kind:/path/to/var"])
+    def test_cli_invokes_show_correctly(self, cli_invocation, output, client):
+        client.get_resource.assert_called_once_with('kind', '/path/to/var')
+
+    @cli_test(["show", "-i", "kind:/path/to/var"], show_output={"foo": "A", "bar": "B"})
+    def test_cli_show_outputs_formatted_json(self, cli_invocation, output, client):
+        self.assertEquals('{\n    "foo": "A",\n    "bar": "B"\n}\n', output)
+
     @cli_test(["user"])
     def test_cli_user_retuns_main_help(self, cli_invocation, output, client):
         self.assertIn("Usage:\n", output)

--- a/test/test_unit_init_logic.py
+++ b/test/test_unit_init_logic.py
@@ -27,7 +27,6 @@ EXPECTED_CONFIG = \
 class InitLogicTest(unittest.TestCase):
     conjurrc_data = ConjurrcData("my_url", "myorg", None)
     ssl_service = SSLClient
-    capture_stream = io.StringIO()
     init_logic = InitLogic(ssl_service)
 
     '''

--- a/test/test_unit_show_controller.py
+++ b/test/test_unit_show_controller.py
@@ -1,0 +1,31 @@
+from contextlib import redirect_stdout
+import io
+import json
+import unittest
+from unittest.mock import MagicMock
+from conjur_api import Client
+from conjur_api.errors.errors import HttpStatusError
+import conjur
+from conjur.logic.show_logic import ShowLogic
+from conjur.controller.show_controller import ShowController
+
+
+class ShowControllerTest(unittest.TestCase):
+    capture_stream = io.StringIO()
+
+    def test_show_resource_id_without_kind_raises_missing_required_parameter_exception(self):
+        client = Client
+        mock_show_logic = ShowLogic(client)
+        mock_show_controller = ShowController(mock_show_logic)
+
+        with self.assertRaises(conjur.errors.MissingRequiredParameterException):
+            mock_show_controller.load("resource_id") # missing kind (kind:resource_id)
+
+    def test_show_not_found_error_raises_general_https_exception(self):
+        client = Client
+        mock_show_logic = ShowLogic(client)
+        mock_show_controller = ShowController(mock_show_logic)
+        mock_show_logic.show = MagicMock(side_effect=HttpStatusError(status=404))
+
+        with self.assertRaises(HttpStatusError):
+            mock_show_controller.load("variable:myvar")

--- a/test/test_unit_show_logic.py
+++ b/test/test_unit_show_logic.py
@@ -1,0 +1,16 @@
+import unittest
+from unittest.mock import patch
+
+from conjur_api import Client
+from conjur.data_object import ConjurrcData
+from conjur.logic.credential_provider.file_credentials_provider import FileCredentialsProvider
+from conjur.logic.show_logic import ShowLogic
+
+
+class ShowLogicTest(unittest.TestCase):
+    @patch('conjur_api.Client.get_resource')
+    def test_show_calls_get_resource(self, mock_show):
+        mock_client = Client
+        mock_show_logic = ShowLogic(mock_client)
+        mock_show_logic.show('some_kind', 'some_id')
+        mock_show.assert_called_once_with('some_kind', 'some_id')

--- a/test/util/test_infrastructure.py
+++ b/test/util/test_infrastructure.py
@@ -25,7 +25,7 @@ def integration_test(should_run_as_process=False):
         return test_wrapper_func
     return function_decorator
 
-def cli_test(cli_args=[], integration=False, get_many_output=None, get_output=None, list_output=None,
+def cli_test(cli_args=[], integration=False, get_many_output=None, get_output=None, list_output=None, show_output=None,
              policy_change_output={}, whoami_output={}, rotate_api_key_output={}):
     cli_command = 'cli {}'.format(' '.join(cli_args))
     def test_cli_decorator(original_function):
@@ -37,6 +37,7 @@ def cli_test(cli_args=[], integration=False, get_many_output=None, get_output=No
             client_instance_mock.get_many.return_value = get_many_output
             client_instance_mock.rotate_api_key.return_value = rotate_api_key_output
             client_instance_mock.list.return_value = list_output
+            client_instance_mock.get_resource.return_value = show_output
             client_instance_mock.load_policy_file.return_value = policy_change_output
             client_instance_mock.replace_policy_file.return_value = policy_change_output
             client_instance_mock.update_policy_file.return_value = policy_change_output


### PR DESCRIPTION
Depends on https://github.com/cyberark/conjur-api-python/pull/31

### Desired Outcome

Add the "show" command which existed in the [Ruby CLI](https://github.com/cyberark/cyberark-conjur-cli-docker-based/blob/main/lib/conjur/command/resources.rb#L23) but was not added to the Python CLI.

### Implemented Changes

Added support for command with syntax `conjur show -i variable:path/to/var`

### Connected Issue/Story

Resolves #218

CyberArk internal issue link: [ONYX-23088](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23088)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [ONYX-22999](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22999)
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
