### PR TITLE
Add Role exists command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [7.2.0] - 2022-07-11
+## [7.2.0] - 2022-08-02
 
 ### Added
+- Add "role" command and "exists" subcommand
+  [cyberark/cyberark-conjur-cli#417](https://github.com/cyberark/cyberark-conjur-cli/pull/417)
 - Add "show" command
   [cyberark/cyberark-conjur-cli#416](https://github.com/cyberark/cyberark-conjur-cli/pull/416)
 - Support authn-ldap

--- a/conjur/argument_parser/_init_parser.py
+++ b/conjur/argument_parser/_init_parser.py
@@ -70,7 +70,7 @@ class InitParser:
                                   help='Optional- state if you want to work with self-signed certificate')
         init_options.add_argument('--force-netrc',
                                   action='store_true', dest='force_netrc',
-                                  help='Optional- force the CLI to use a file-based credential storage in'
+                                  help='Optional- force the CLI to use a file-based credential storage in '
                                        '$HOME/.netrc rather than OS-native keystore (for compatibility with Summon)')
         init_options.add_argument('--force',
                                   action='store_true',

--- a/conjur/argument_parser/_role_parser.py
+++ b/conjur/argument_parser/_role_parser.py
@@ -1,0 +1,81 @@
+"""
+Module For the RoleParser
+"""
+import argparse
+from conjur.argument_parser.parser_utils import command_description, command_epilog, formatter, \
+    title_formatter
+from conjur.wrapper.argparse_wrapper import ArgparseWrapper
+
+
+# pylint: disable=too-few-public-methods
+class RoleParser:
+    """Partial class of the ArgParseBuilder.
+    This class add the Role subparser to the ArgParseBuilder parser."""
+
+    def __init__(self):
+        self.resource_subparsers = None  # here to reduce warnings on resource_subparsers not exist
+        raise NotImplementedError("this is partial class of ArgParseBuilder")
+
+    def add_role_parser(self):
+        """
+        Method adds role parser functionality to parser
+        """
+        role_parser = self._create_role_parser()
+        role_subparser = role_parser.add_subparsers(title="Subcommand", dest='action')
+
+        self._add_role_exists(role_subparser)
+        self._add_role_options(role_parser)
+
+        return self
+
+    def _create_role_parser(self):
+        role_name = 'role - Manage roles'
+        role_usage = 'conjur [global options] role <subcommand> [options] [args]'
+
+        role_parser = self.resource_subparsers \
+            .add_parser('role',
+                        help='Manage roles',
+                        description=command_description(role_name,
+                                                        role_usage),
+                        epilog=command_epilog(
+                            'conjur role exists -i host:hosts/myhost\t\t\t'
+                            'Returns true if the host role hosts/myhost exists\n',
+                            command='role',
+                            subcommands=['exists']),
+                        usage=argparse.SUPPRESS,
+                        add_help=False,
+                        formatter_class=formatter)
+        return role_parser
+
+    @staticmethod
+    def _add_role_exists(role_subparser: ArgparseWrapper):
+        role_get_name = 'exists - Determines whether a role exists'
+        role_get_usage = 'conjur [global options] role exists [options] [args]'
+
+        role_get_subcommand_parser = role_subparser \
+            .add_parser(name="exists",
+                        help='Determines whether a role exists',
+                        description=command_description(
+                            role_get_name, role_get_usage),
+                        epilog=command_epilog(
+                            'conjur role exists -i host:hosts/myhost\t\t\t'
+                            'Returns true if the host role hosts/myhost exists\n'),
+                        usage=argparse.SUPPRESS,
+                        add_help=False,
+                        formatter_class=formatter)
+        role_get_options = role_get_subcommand_parser.add_argument_group(
+            title=title_formatter("Options"))
+        role_get_options.add_argument('-i', '--id', dest='identifier', metavar='VALUE',
+                                          help='Provide role identifier',
+                                          required=True)
+        role_get_options.add_argument('--json', dest='json_response', action='store_true',
+                                          help='Output a JSON response with a single field, exists')
+        role_get_options.add_argument('-h', '--help', action='help',
+                                          help='Display help screen and exit')
+
+
+    @staticmethod
+    def _add_role_options(role_parser: ArgparseWrapper):
+        policy_options = role_parser.add_argument_group(title=title_formatter("Options"))
+        policy_options.add_argument('-h', '--help', action='help',
+                                    help='Display help screen and exit')

--- a/conjur/argument_parser/_show_parser.py
+++ b/conjur/argument_parser/_show_parser.py
@@ -46,7 +46,7 @@ class ShowParser:
         show_options = show_subparser.add_argument_group(title=title_formatter("Options"))
 
         show_options.add_argument('-i', '--id', dest='identifier', metavar='VALUE',
-                                          help='Provide variable identifier',
+                                          help='Provide object identifier',
                                           required=True)
 
         show_options.add_argument('-h', '--help', action='help',

--- a/conjur/argument_parser/argparse_builder.py
+++ b/conjur/argument_parser/argparse_builder.py
@@ -16,6 +16,7 @@ from conjur.argument_parser._show_parser import ShowParser
 from conjur.argument_parser._screen_options_parser import ScreenOptionsParser
 from conjur.argument_parser._user_parser import UserParser
 from conjur.argument_parser._variable_parser import VariableParser
+from conjur.argument_parser._role_parser import RoleParser
 from conjur.argument_parser._whoami_parser import WhoamiParser
 from conjur.argument_parser._hostfactory_parser import HostFactoryParser
 
@@ -30,6 +31,7 @@ class ArgParseBuilder(InitParser,
                       ShowParser,
                       UserParser,
                       VariableParser,
+                      RoleParser,
                       WhoamiParser,
                       HostFactoryParser,
                       ScreenOptionsParser):

--- a/conjur/cli.py
+++ b/conjur/cli.py
@@ -66,6 +66,7 @@ class Cli:
             .add_policy_parser() \
             .add_user_parser() \
             .add_variable_parser() \
+            .add_role_parser() \
             .add_whoami_parser() \
             .add_hostfactory_parser() \
             .add_main_screen_options() \
@@ -165,6 +166,9 @@ class Cli:
 
         elif resource == 'variable':
             cli_actions.handle_variable_logic(args, client)
+
+        elif resource == 'role':
+            cli_actions.handle_role_logic(args, client)
 
         elif resource == 'policy':
             policy_data = PolicyData(action=args.action, branch=args.branch, file=args.file)

--- a/conjur/cli_actions.py
+++ b/conjur/cli_actions.py
@@ -23,9 +23,9 @@ from conjur.errors import ConflictingParametersException, FileNotFoundException,
 from conjur.logic.hostfactory_logic import HostFactoryLogic
 from conjur.controller import InitController, LoginController, \
     LogoutController, ListController, VariableController, \
-    PolicyController, UserController, HostController
+    PolicyController, UserController, HostController, RoleController
 from conjur.logic import InitLogic, LoginLogic, LogoutLogic, ListLogic, VariableLogic, \
-    PolicyLogic, UserLogic
+    PolicyLogic, UserLogic, RoleLogic
 from conjur.data_object import ConjurrcData, UserInputData, HostResourceData, ListData, VariableData, \
     PolicyData
 from conjur.logic.show_logic import ShowLogic
@@ -200,6 +200,25 @@ def handle_variable_logic(args: list = None, client=None):
         variable_controller = VariableController(variable_logic=variable_logic,
                                                  variable_data=variable_data)
         variable_controller.set_variable()
+
+
+def handle_role_logic(args: list = None, client=None):
+    """
+    Method wraps the role call logic
+    """
+    role_logic = RoleLogic(client)
+    role_controller = RoleController(role_logic=role_logic)
+
+    if args.action == 'exists':
+        role_controller.role_exists(identifier=args.identifier,
+                                    json_response=args.json_response)
+    elif args.action == 'members':
+        #TODO: implement
+        pass
+    elif args.action == 'memberships':
+        #TODO: implement
+        pass
+
 
 
 def handle_policy_logic(policy_data: PolicyData = None, client=None):

--- a/conjur/controller/__init__.py
+++ b/conjur/controller/__init__.py
@@ -12,3 +12,4 @@ from conjur.controller.logout_controller import LogoutController
 from conjur.controller.policy_controller import PolicyController
 from conjur.controller.user_controller import UserController
 from conjur.controller.variable_controller import VariableController
+from conjur.controller.role_controller import RoleController

--- a/conjur/controller/role_controller.py
+++ b/conjur/controller/role_controller.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+"""
+RoleController module
+
+This module is the controller that facilitates all list actions
+required to successfully execute the ROLE command
+"""
+import json
+import sys
+from conjur.logic.role_logic import RoleLogic
+from conjur.role import Role
+
+# pylint: disable=too-few-public-methods
+class RoleController:
+    """
+    RoleController
+
+    This class represents the Presentation Layer for the ROLE command
+    """
+    def __init__(self, role_logic:RoleLogic):
+        self.role_logic = role_logic
+
+    def role_exists(self, identifier: str, json_response: str = False):
+        """
+        Method that facilitates get call to the logic
+        """
+
+        role = Role.from_full_id(identifier)
+        result = self.role_logic.role_exists(role.kind, role.identifier)
+
+        if json_response:
+            sys.stdout.write(f"{json.dumps({'exists' : result}, indent=4)}\n")
+        else:
+            sys.stdout.write(str(result).lower()+'\n')

--- a/conjur/logic/__init__.py
+++ b/conjur/logic/__init__.py
@@ -11,3 +11,4 @@ from conjur.logic.login_logic import LoginLogic
 from conjur.logic.logout_logic import LogoutLogic
 from conjur.logic.policy_logic import PolicyLogic
 from conjur.logic.variable_logic import VariableLogic
+from conjur.logic.role_logic import RoleLogic

--- a/conjur/logic/role_logic.py
+++ b/conjur/logic/role_logic.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+"""
+RoleLogic module
+
+This module is the business logic for executing the ROLE command
+"""
+
+# Builtins
+import logging
+
+from conjur_api.errors.errors import HttpStatusError
+
+# pylint: disable=too-few-public-methods
+class RoleLogic:
+    """
+    RoleLogic
+
+    This class holds the business logic for executing and manipulating
+    returned data
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+    # pylint: disable=logging-fstring-interpolation
+    def role_exists(self, kind: str, role_id: str) -> bool:
+        """
+        Method to handle role exists action
+        """
+        logging.debug(role_id)
+
+        role_value = None
+
+        try:
+            role_value = self.client.get_role(kind, role_id)
+        except HttpStatusError as err:
+            if '404' in str(err):
+                return False
+            raise err
+
+        return role_value is not None

--- a/conjur/resource.py
+++ b/conjur/resource.py
@@ -17,7 +17,7 @@ class Resource:
     @classmethod
     def from_full_id(cls, full_id: str):
         """
-        Factory method for
+        Factory method for creating a Resource object from a full ID.
         """
         id_parts = full_id.split(':', 2)
         if len(id_parts) == 3:

--- a/conjur/role.py
+++ b/conjur/role.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""
+Role module
+"""
+
+
+# pylint: disable=duplicate-code
+from conjur.errors import MissingRequiredParameterException
+
+
+class Role:
+    """
+    DTO class that represents a role in Conjur.
+    """
+
+    @classmethod
+    def from_full_id(cls, full_id: str):
+        """
+        Factory method for creating a Role object from a full ID.
+        """
+        id_parts = full_id.split(':', 2)
+        if len(id_parts) == 3:
+            # If identifier contains also the account part, remove it.
+            id_parts.pop(0)
+        elif len(id_parts) != 2:
+            raise MissingRequiredParameterException(
+                f"Role ID missing 'kind:' prefix: {full_id}")
+
+        return Role(kind=id_parts[0], identifier=id_parts[1])
+
+    def __init__(self, kind: str, identifier: str):
+        """
+        Used for representing Conjur roles
+        """
+        self.kind = kind
+        self.identifier = identifier
+
+    def full_id(self):
+        """
+        Method for building the full role ID in the format 'user:someuser' for example
+        """
+        return f"{self.kind}:{self.identifier}"

--- a/test/test_integration_role.py
+++ b/test/test_integration_role.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+"""
+CLI Show Integration tests
+This test file handles the main test flows for the role command
+"""
+from contextlib import redirect_stderr
+import io
+import os
+from unittest.mock import patch
+
+from conjur.constants import LOGIN_IS_REQUIRED
+from test.util.test_infrastructure import integration_test
+from test.util.test_runners.integration_test_case import IntegrationTestCaseBase
+from test.util import test_helpers as utils
+
+
+# Not coverage tested since integration tests don't run in
+# the same build step
+class CliIntegrationTestShow(IntegrationTestCaseBase):  # pragma: no cover
+    capture_stream = io.StringIO()
+
+    def __init__(self, testname, client_params=None, environment_params=None):
+        super(CliIntegrationTestShow, self).__init__(testname, client_params, environment_params)
+
+    # *************** HELPERS ***************
+
+    def setUp(self):
+        self.setup_cli_params({})
+        # Used to configure the CLI and login to run tests
+        utils.setup_cli(self)
+        return self.invoke_cli(self.cli_auth_params,
+                               ['policy', 'replace', '-b', 'root', '-f', self.environment.path_provider.get_policy_path("list")])
+
+    # *************** TESTS ***************
+
+    @integration_test()
+    def test_role_exists_insecure_prints_warning_in_log(self):
+        with self.assertLogs('', level='DEBUG') as mock_log:
+            self.invoke_cli(self.cli_auth_params,
+                                     ['--insecure', 'role', 'exists', '-i', 'user:someuser'])
+            self.assertIn("Warning: Running the command with '--insecure' makes your system vulnerable to security attacks",
+                          str(mock_log.output))
+
+    @integration_test()
+    def test_role_without_action_returns_usage(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                            ['role'])
+        self.assertIn("Usage:\n  conjur", output)
+
+    @integration_test(True)
+    def test_role_short_with_help_returns_role_help(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', '-h'])
+        self.assertIn("Name:\n  role", output)
+
+    @integration_test(True)
+    def test_role_long_with_help_returns_role_help(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', '--help'])
+        self.assertIn("Name:\n  role", output)
+
+    @integration_test(True)
+    def test_role_exists_short_with_help_returns_role_exists_help(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-h'])
+        self.assertIn("Name:\n  exists", output)
+
+    @integration_test(True)
+    def test_role_exists_long_with_help_returns_role_exists_help(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '--help'])
+        self.assertIn("Name:\n  exists", output)
+
+    @integration_test()
+    def test_role_exists_without_id_returns_help(self):
+        with redirect_stderr(self.capture_stream):
+            self.invoke_cli(self.cli_auth_params,
+                            ['role', 'exists'], exit_code=1)
+        self.assertIn("Error the following arguments are required:", self.capture_stream.getvalue())
+
+    @integration_test()
+    def test_role_exists_without_prefix_returns_help(self):
+        with redirect_stderr(self.capture_stream):
+            self.invoke_cli(self.cli_auth_params,
+                            ['role', 'exists', '-i', 'someuser'], exit_code=1)
+        self.assertIn("Error the following arguments are required:", self.capture_stream.getvalue())
+
+    @integration_test(True)
+    def test_role_exists_long_role_id_returns_result(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '--id=user:someuser'])
+        self.assertIn('true', output)
+
+    @integration_test(True)
+    def test_role_exists_short_options_returns_result(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-i', 'user:someuser'])
+        self.assertIn('true', output)
+
+    @integration_test(True)
+    def test_role_exists_returns_false_if_not_exist(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-i', 'user:fakeuser'])
+        self.assertIn('false', output)
+
+    @integration_test(True)
+    def test_role_exists_host_returns_result(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-i', 'host:anotherhost'])
+        self.assertIn('true', output)
+
+    @integration_test(True)
+    def test_role_exists_layer_returns_result(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-i', 'layer:somelayer'])
+        self.assertIn('true', output)
+
+    @integration_test(True)
+    def test_role_exists_group_returns_result(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-i', 'group:somegroup'])
+        self.assertIn('true', output)
+
+    @integration_test(True)
+    def test_role_exists_policy_returns_result(self):
+        output = self.invoke_cli(self.cli_auth_params,
+                                 ['role', 'exists', '-i', 'policy:root'])
+        self.assertIn('true', output)
+
+
+    '''
+    Validates that when the user isn't logged in and makes a request,
+    they are prompted to login first and then the command is executed
+    '''
+    @integration_test()
+    @patch('builtins.input', return_value='admin')
+    def test_role_exists_without_user_logged_in_prompts_login_and_performs_role_exists(self, mock_input):
+        # TEST_ENV is set to False so we will purposely be prompted to login
+        os.environ['TEST_ENV'] = 'False'
+        try:
+            utils.delete_credentials()
+        except OSError:
+            pass
+
+        with patch('getpass.getpass', return_value=self.client_params.env_api_key):
+            output = self.invoke_cli(self.cli_auth_params,
+                                     ['role', 'exists', '-i', 'user:someuser'])
+
+            self.assertIn(LOGIN_IS_REQUIRED, output)
+            self.assertIn("Successfully logged in to Conjur", output)
+            self.assertIn('true', output)
+        os.environ['TEST_ENV'] = 'True'

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -106,6 +106,10 @@ Copyright (c) {time.strftime("%Y")} CyberArk Software Ltd. All rights reserved.
             output, client):
         self.assertEquals('{\n    "foo": "A",\n    "bar": "B"\n}\n', output)
 
+    @cli_test(["role", "exists", "-i", "somekind:/path/to/role"])
+    def test_cli_invokes_role_exists_correctly(self, cli_invocation, output, client):
+        client.get_role.assert_called_once_with('somekind', '/path/to/role')
+
     @cli_test(["policy"])
     def test_cli_policy_parser_doesnt_break_without_action(self, cli_invocation, output, client):
         self.assertIn("Usage:", output)

--- a/test/test_unit_role_logic.py
+++ b/test/test_unit_role_logic.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from conjur_api import Client
+
+from conjur.logic.role_logic import RoleLogic
+from conjur_api.errors.errors import HttpStatusError
+
+MockRole = {'created_at': None, 'id': 'default:somekind:someapp', 'policy': 'default:policy:test', 
+            'members': []}
+
+class RoleLogicTest(unittest.TestCase):
+    client = Client
+    role_logic = RoleLogic(client)
+
+    def test_role_logic_constructor(self):
+        mock_client = None
+        role_logic = RoleLogic(mock_client)
+        self.assertEquals(role_logic.client, mock_client)
+
+    '''
+    Raises exception when the request is missing a required parameter
+    '''
+    def test_get_role_missing_parameter_raises_exception(self):
+        with self.assertRaises(TypeError):
+            self.role_logic.role_exists('somekind')
+
+    '''
+    Returns true when the API returns an existing role
+    '''
+    def test_role_exists_response(self):
+        self.client.get_role = MagicMock(return_value=MockRole)
+        self.assertEqual(self.role_logic.role_exists('somekind', 'someapp'), True)
+
+    '''
+    Returns false when the API returns a 404 not found error
+    '''
+    def test_role_exists_response_role_not_found(self):
+        self.role_logic.client.get_role = MagicMock(side_effect=HttpStatusError(status=404, message="Not Found"))
+        self.assertEqual(self.role_logic.role_exists('somekind', 'someapp'), False)
+
+    '''
+    Raises exception when another error besides 404 occurs
+    '''
+    def test_role_exists_raises_exception_other_http_error(self):
+        self.role_logic.client.get_role = MagicMock(side_effect=HttpStatusError(status=500, message="Server Error"))
+        with self.assertRaises(HttpStatusError):
+            self.role_logic.role_exists('somekind', 'someapp')


### PR DESCRIPTION
Depends on https://github.com/cyberark/conjur-api-python/pull/30

### Desired Outcome

Add the Role command and `exists` subcommand which existed in the [Ruby CLI](https://github.com/cyberark/cyberark-conjur-cli-docker-based/main/lib/conjur/command/roles.rb#L24) but was not added to the Python CLI.

### Implemented Changes

Added support for command with syntax `conjur role exists -i someuser -k user`

### Connected Issue/Story

CyberArk internal issue link: [ONYX-23085](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23085)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [ONYX-22999](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22999)
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
