### PR TITLE
Add role memberships command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [7.2.0] - 2022-08-02
 
 ### Added
-- Add "role" command and "exists" subcommand
+- Add "role" command and "exists", "memberships" subcommands
   [cyberark/cyberark-conjur-cli#417](https://github.com/cyberark/cyberark-conjur-cli/pull/417)
+  [cyberark/cyberark-conjur-cli#419](https://github.com/cyberark/cyberark-conjur-cli/pull/419)
 - Add "resource" command and "exists" subcommand
   [cyberark/cyberark-conjur-cli#418](https://github.com/cyberark/cyberark-conjur-cli/pull/418)
 - Add "show" command

--- a/conjur/argument_parser/_role_parser.py
+++ b/conjur/argument_parser/_role_parser.py
@@ -24,6 +24,7 @@ class RoleParser:
         role_subparser = role_parser.add_subparsers(title="Subcommand", dest='action')
 
         self._add_role_exists(role_subparser)
+        self._add_role_memberships(role_subparser)
         self._add_role_options(role_parser)
 
         return self
@@ -41,7 +42,7 @@ class RoleParser:
                             'conjur role exists -i host:hosts/myhost\t\t\t'
                             'Returns true if the host role hosts/myhost exists\n',
                             command='role',
-                            subcommands=['exists']),
+                            subcommands=['exists', 'memberships']),
                         usage=argparse.SUPPRESS,
                         add_help=False,
                         formatter_class=formatter)
@@ -73,6 +74,32 @@ class RoleParser:
         role_exists_options.add_argument('-h', '--help', action='help',
                                           help='Display help screen and exit')
 
+    @staticmethod
+    def _add_role_memberships(role_subparser: ArgparseWrapper):
+        role_get_name = 'memberships - Lists role memberships. The role membership list is' \
+                        'recursively expanded by default'
+        role_get_usage = 'conjur [global options] role memberships [options] [args]'
+
+        role_get_subcommand_parser = role_subparser \
+            .add_parser(name="memberships",
+                        help='Lists role memberships. The role membership list is recursively expanded by default',
+                        description=command_description(
+                            role_get_name, role_get_usage),
+                        epilog=command_epilog(
+                            'conjur role memberships -i host:hosts/myhost\t\t\t'
+                            'Shows roles which hosts/myhost belongs to\n'),
+                        usage=argparse.SUPPRESS,
+                        add_help=False,
+                        formatter_class=formatter)
+        role_get_options = role_get_subcommand_parser.add_argument_group(
+            title=title_formatter("Options"))
+        role_get_options.add_argument('-i', '--id', dest='identifier', metavar='VALUE',
+                                          help='Provide role identifier',
+                                          required=True)
+        role_get_options.add_argument('-d', '--direct', dest='direct', action='store_true',
+                                          help='Whether to show direct memberships only')
+        role_get_options.add_argument('-h', '--help', action='help',
+                                          help='Display help screen and exit')
 
     @staticmethod
     def _add_role_options(role_parser: ArgparseWrapper):

--- a/conjur/cli_actions.py
+++ b/conjur/cli_actions.py
@@ -225,13 +225,9 @@ def handle_role_logic(args: list = None, client=None):
     if args.action == 'exists':
         role_controller.role_exists(identifier=args.identifier,
                                     json_response=args.json_response)
-    elif args.action == 'members':
-        #TODO: implement
-        pass
     elif args.action == 'memberships':
-        #TODO: implement
-        pass
-
+        role_controller.role_memberships(identifier=args.identifier,
+                                         direct=args.direct)
 
 
 def handle_policy_logic(policy_data: PolicyData = None, client=None):

--- a/conjur/controller/role_controller.py
+++ b/conjur/controller/role_controller.py
@@ -7,6 +7,7 @@ This module is the controller that facilitates all list actions
 required to successfully execute the ROLE command
 """
 import sys
+
 from conjur.logic.role_logic import RoleLogic
 from conjur.role import Role
 from conjur.util import util_functions
@@ -33,3 +34,12 @@ class RoleController:
             util_functions.print_json_result({'exists' : result})
         else:
             sys.stdout.write(str(result).lower()+'\n')
+
+    def role_memberships(self, identifier: str, direct: bool = False):
+        """
+        Method that facilitates get call to the logic
+        """
+
+        role = Role.from_full_id(identifier)
+        result = self.role_logic.role_memberships(role.kind, role.identifier, direct)
+        util_functions.print_json_result(result)

--- a/conjur/logic/role_logic.py
+++ b/conjur/logic/role_logic.py
@@ -40,3 +40,12 @@ class RoleLogic:
             raise err
 
         return role_value is not None
+
+    # pylint: disable=logging-fstring-interpolation
+    def role_memberships(self, kind: str, role_id: str, direct: bool = False) -> bool:
+        """
+        Method to handle role memberships action
+        """
+        logging.debug(role_id)
+
+        return self.client.role_memberships(kind, role_id, direct)

--- a/test/test_config/role_policy.yml
+++ b/test/test_config/role_policy.yml
@@ -1,0 +1,17 @@
+- !layer somelayer
+- !group somegroup
+- !group someothergroup
+- !host anotherhost
+- !user someuser
+- !variable one/password
+- !webservice somewebservice
+
+- !grant
+  role: !group somegroup
+  member:
+  - !user someuser
+
+- !grant
+  role: !group someothergroup
+  member:
+  - !group somegroup

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -110,6 +110,10 @@ Copyright (c) {time.strftime("%Y")} CyberArk Software Ltd. All rights reserved.
     def test_cli_invokes_role_exists_correctly(self, cli_invocation, output, client):
         client.get_role.assert_called_once_with('somekind', '/path/to/role')
 
+    @cli_test(["role", "memberships", "-i", "somekind:/path/to/role", "-d"], memberships_output=['abc', 'def'])
+    def test_cli_invokes_role_memberships_correctly(self, cli_invocation, output, client):
+        client.role_memberships.assert_called_once_with('somekind', '/path/to/role', True)
+
     @cli_test(["policy"])
     def test_cli_policy_parser_doesnt_break_without_action(self, cli_invocation, output, client):
         self.assertIn("Usage:", output)

--- a/test/test_unit_role_controller.py
+++ b/test/test_unit_role_controller.py
@@ -14,3 +14,11 @@ class RoleControllerTest(unittest.TestCase):
 
         with self.assertRaises(conjur.errors.MissingRequiredParameterException):
             mock_role_controller.role_exists("resource_id") # missing kind (kind:resource_id)
+
+    def test_role_memberships_resource_id_without_kind_raises_missing_required_parameter_exception(self):
+        client = Client
+        mock_role_logic = RoleLogic(client)
+        mock_role_controller = RoleController(mock_role_logic)
+
+        with self.assertRaises(conjur.errors.MissingRequiredParameterException):
+            mock_role_controller.role_memberships("resource_id") # missing kind (kind:resource_id)

--- a/test/test_unit_role_logic.py
+++ b/test/test_unit_role_logic.py
@@ -8,6 +8,7 @@ from conjur_api.errors.errors import HttpStatusError
 
 MockRole = {'created_at': None, 'id': 'default:somekind:someapp', 'policy': 'default:policy:test', 
             'members': []}
+MockMemberships = ['default:policy:test', 'default:group:somegroup']
 
 class RoleLogicTest(unittest.TestCase):
     client = Client
@@ -21,7 +22,7 @@ class RoleLogicTest(unittest.TestCase):
     '''
     Raises exception when the request is missing a required parameter
     '''
-    def test_get_role_missing_parameter_raises_exception(self):
+    def test_role_exists_missing_parameter_raises_exception(self):
         with self.assertRaises(TypeError):
             self.role_logic.role_exists('somekind')
 
@@ -46,3 +47,25 @@ class RoleLogicTest(unittest.TestCase):
         self.role_logic.client.get_role = MagicMock(side_effect=HttpStatusError(status=500, message="Server Error"))
         with self.assertRaises(HttpStatusError):
             self.role_logic.role_exists('somekind', 'someapp')
+
+    '''
+    Raises exception when the request is missing a required parameter
+    '''
+    def test_role_memberships_missing_parameter_raises_exception(self):
+        with self.assertRaises(TypeError):
+            self.role_logic.role_memberships('somekind')
+
+    '''
+    Returns list of memberships from the API call
+    '''
+    def test_role_memberships_response(self):
+        self.client.role_memberships = MagicMock(return_value=MockMemberships)
+        self.assertEqual(self.role_logic.role_memberships('somekind', 'someuser'), MockMemberships)
+
+    '''
+    Raises exception when API error occurs
+    '''
+    def test_role_memberships_raises_exception_http_error(self):
+        self.role_logic.client.role_memberships = MagicMock(side_effect=HttpStatusError(status=404, message="Not found"))
+        with self.assertRaises(HttpStatusError):
+            self.role_logic.role_memberships('somekind', 'someapp')

--- a/test/util/test_infrastructure.py
+++ b/test/util/test_infrastructure.py
@@ -26,7 +26,7 @@ def integration_test(should_run_as_process=False):
     return function_decorator
 
 def cli_test(cli_args=[], integration=False, get_many_output=None, get_output=None, list_output=None, show_output=None,
-             policy_change_output={}, whoami_output={}, rotate_api_key_output={}):
+             memberships_output=None, policy_change_output={}, whoami_output={}, rotate_api_key_output={}):
     cli_command = 'cli {}'.format(' '.join(cli_args))
     def test_cli_decorator(original_function):
         @wraps(original_function)
@@ -42,6 +42,7 @@ def cli_test(cli_args=[], integration=False, get_many_output=None, get_output=No
             client_instance_mock.replace_policy_file.return_value = policy_change_output
             client_instance_mock.update_policy_file.return_value = policy_change_output
             client_instance_mock.whoami.return_value = whoami_output
+            client_instance_mock.role_memberships.return_value = memberships_output
             with self.assertRaises(SystemExit) as sys_exit:
                 with redirect_stdout(capture_stream):
                     with patch.object(sys, 'argv', ["cli"] + cli_args), \


### PR DESCRIPTION
### Desired Outcome

Add support for the 'role memberships' command that previously existing in the Ruby CLI.

### Implemented Changes

Add CLI functionality that allows commands with the syntax `conjur role memberships -i user:someuser`.
Support both recursive (default) and direct membership queries (-d / --direct). Drop support for the --system flag which served no purpose.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-23087](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23087)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [ONYX-22999](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22999)
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
