### PR TITLE
Use new `role_exists` API method

### DIFF
--- a/conjur/logic/resource_logic.py
+++ b/conjur/logic/resource_logic.py
@@ -6,7 +6,7 @@ ResourceLogic module
 This module is the business logic for executing the resource command
 """
 
-import json
+import logging
 
 # pylint: disable=too-few-public-methods
 class ResourceLogic:
@@ -19,8 +19,10 @@ class ResourceLogic:
     def __init__(self, client):
         self.client = client
 
-    def exists(self, kind: str, resource_id: str) -> json:
+    def exists(self, kind: str, resource_id: str) -> bool:
         """
         Method for checking for existence of a resource
         """
+        logging.debug(resource_id)
+
         return self.client.resource_exists(kind, resource_id)

--- a/conjur/logic/role_logic.py
+++ b/conjur/logic/role_logic.py
@@ -9,8 +9,6 @@ This module is the business logic for executing the ROLE command
 # Builtins
 import logging
 
-from conjur_api.errors.errors import HttpStatusError
-
 # pylint: disable=too-few-public-methods
 class RoleLogic:
     """
@@ -30,16 +28,7 @@ class RoleLogic:
         """
         logging.debug(role_id)
 
-        role_value = None
-
-        try:
-            role_value = self.client.get_role(kind, role_id)
-        except HttpStatusError as err:
-            if '404' in str(err):
-                return False
-            raise err
-
-        return role_value is not None
+        return self.client.role_exists(kind, role_id)
 
     # pylint: disable=logging-fstring-interpolation
     def role_memberships(self, kind: str, role_id: str, direct: bool = False) -> bool:

--- a/test/test_unit_cli.py
+++ b/test/test_unit_cli.py
@@ -108,7 +108,7 @@ Copyright (c) {time.strftime("%Y")} CyberArk Software Ltd. All rights reserved.
 
     @cli_test(["role", "exists", "-i", "somekind:/path/to/role"])
     def test_cli_invokes_role_exists_correctly(self, cli_invocation, output, client):
-        client.get_role.assert_called_once_with('somekind', '/path/to/role')
+        client.role_exists.assert_called_once_with('somekind', '/path/to/role')
 
     @cli_test(["role", "memberships", "-i", "somekind:/path/to/role", "-d"], memberships_output=['abc', 'def'])
     def test_cli_invokes_role_memberships_correctly(self, cli_invocation, output, client):


### PR DESCRIPTION
Depends on https://github.com/cyberark/conjur-api-python/pull/35

### Implemented Changes

Refactored the "role exists" command to use the new `role_exists` method in the API library which has a smaller network footprint and handles the different status codes for us.

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
