### PR TITLE
Updates 'init' command's cert_file property

### DIFF
--- a/conjur/controller/init_controller.py
+++ b/conjur/controller/init_controller.py
@@ -79,7 +79,7 @@ class InitController:
             fetched_certificate = self._get_server_certificate(formatted_conjur_url)
             self._write_certificate(fetched_certificate)
         elif mode in [SslVerificationMode.INSECURE, SslVerificationMode.TRUST_STORE]:
-            self.conjurrc_data.cert_file = ""
+            self.conjurrc_data.cert_file = None
 
     def _prompt_for_conjur_url(self):
         """

--- a/test/test_integration_configurations.py
+++ b/test/test_integration_configurations.py
@@ -45,7 +45,7 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
     # *************** INIT CONFIGURATION TESTS ***************
 
     '''
-    Validates that the conjurrc cert_file entry is blank when run in --insecure mode
+    Validates that the conjurrc cert_file entry is null when run in --insecure mode
     '''
 
     @integration_test(True)
@@ -56,7 +56,21 @@ class CliIntegrationTestConfigurations(IntegrationTestCaseBase):
                         ['--insecure', 'init', '--url', self.client_params.hostname, '--account',
                          'someaccount'])
 
-        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, '')
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, None)
+
+    '''
+    Validates that the conjurrc cert_file entry is null when no cert-related flag is provided
+    '''
+
+    @integration_test(True)
+    @patch('builtins.input', return_value='yes')
+    def test_https_conjurrc_no_cert_provided_leaves_cert_file_empty(self, mock_input):
+        self.setup_cli_params({})
+        self.invoke_cli(self.cli_auth_params,
+                        ['init', '--url', self.client_params.hostname, '--account',
+                         'someaccount'])
+
+        utils.verify_conjurrc_contents('someaccount', self.client_params.hostname, None)
 
     '''
     Validates that cli can't run with insecure + --ca-cert

--- a/test/util/test_helpers.py
+++ b/test/util/test_helpers.py
@@ -65,7 +65,10 @@ def verify_conjurrc_contents(account, hostname, cert, authn_type='authn', servic
         assert f"account: {account}" in lines[1], lines[1]
         assert f"appliance_url: {hostname}" in lines[2], lines[2]
         assert f"authn_type: {authn_type}" in lines[3], lines[3]
-        assert f"cert_file: {cert}" in lines[4], lines[4]
+        if cert:
+            assert f"cert_file: {cert}" in lines[4], lines[4]
+        else:
+            assert "cert_file: null"
         if netrc_path:
             assert f"netrc_path: {netrc_path}" in lines[5], lines[5]
         if service_id:


### PR DESCRIPTION
### Desired Outcome

- Added fixes to the 'init' command to omit empty string paths for Ruby CLI compatibility

### Implemented Changes

- Updated files to remove empty string declarations

### Connected Issue/Story

https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-24956
