### PR TITLE
Allow 422 error message to be Unprocessable Entity or Unprocessable C…

### DIFF
--- a/test/host_factory/test_integration_hostfactory.py
+++ b/test/host_factory/test_integration_hostfactory.py
@@ -20,7 +20,7 @@ INVALID_DURATION_ERROR_MSG = 'Failed to execute command. Reason: ' \
                              'Either \'duration-days\' / \'duration-hours\' / \'duration-minutes\' ' \
                              'are missing or not in the correct format. Solution: provide one of the required ' \
                              'parameters or make sure they are positive numbers'
-ERROR_PATTERN_422 = r"Failed to execute command. Reason: 422 \(Unprocessable Entity\) for url:.*"
+ERROR_PATTERN_422 = r"Failed to execute command. Reason: 422 \(Unprocessable (Entity|Content)\) for url:.*"
 ERROR_PATTERN_404 = r'Failed to execute command. Reason: 404 \(Not Found\) for url:.*'
 ERROR_PATTERN_401 = 'Failed to log in to Conjur. Unable to authenticate with Conjur. ' \
                     r'Reason: 401 \(Unauthorized\) for url:.*'

--- a/test/list_resources/test_integration_list.py
+++ b/test/list_resources/test_integration_list.py
@@ -160,12 +160,12 @@ class CliIntegrationTestList(IntegrationTestCaseBase):  # pragma: no cover
     @integration_test(True)
     def test_list_limit_invalid_param_returns_empty_list(self):
         output = self.invoke_cli(self.cli_auth_params, ['list', '-l', '0'], exit_code=1)
-        self.assertIn("422 (Unprocessable Entity) for url:", output)
+        self.assertRegex(output, r".*422 \(Unprocessable (Entity|Content)\) for url:.*")
 
     @integration_test(True)
     def test_list_limit_string_raises_error(self):
         output = self.invoke_cli(self.cli_auth_params, ['list', '-l', 'somestring'], exit_code=1)
-        self.assertIn("422 (Unprocessable Entity) for url:", output)
+        self.assertRegex(output, r".*422 \(Unprocessable (Entity|Content)\) for url:.*")
 
     '''
     Validates that an invalid input (a negative number) raises an error 
@@ -173,7 +173,7 @@ class CliIntegrationTestList(IntegrationTestCaseBase):  # pragma: no cover
     @integration_test(True)
     def test_list_limit_invalid_negative_param_raises_error(self):
         output = self.invoke_cli(self.cli_auth_params, ['list', '-l', '-5'], exit_code=1)
-        self.assertIn("422 (Unprocessable Entity) for url:", output)
+        self.assertRegex(output, r".*422 \(Unprocessable (Entity|Content)\) for url:.*")
 
     @integration_test()
     def test_list_random_input_raises_error(self):
@@ -217,7 +217,7 @@ class CliIntegrationTestList(IntegrationTestCaseBase):  # pragma: no cover
     @integration_test(True)
     def test_list_offset_negative_raises_error(self):
         output = self.invoke_cli(self.cli_auth_params, ['list', '-o', '-1'], exit_code=1)
-        self.assertIn("422 (Unprocessable Entity) for url:", output)
+        self.assertRegex(output, r".*422 \(Unprocessable (Entity|Content)\) for url:.*")
 
     # This tests is commented out because of a bug in server (https://github.com/cyberark/conjur/issues/1997)
     # where a string is considered valid input for offset. For example, when offset=somestring a list

--- a/test/test_integration_policy.py
+++ b/test/test_integration_policy.py
@@ -111,8 +111,8 @@ class CliIntegrationPolicy(IntegrationTestCaseBase):  # pragma: no cover
         with self.assertLogs('', level='DEBUG') as mock_log:
             with redirect_stderr(self.capture_stream):
                 output = utils.load_policy_from_string(self, policy, exit_code=1)
-            self.assertIn("422 (Unprocessable Entity) for url:", output)
-        self.assertIn("422 Unprocessable Entity {\"error\":{\"code\":\"validation_failed\",\"message\":",
+            self.assertRegex(output, r".*422 \(Unprocessable (Entity|Content)\) for url:.*")
+        self.assertIn("{\"error\":{\"code\":\"validation_failed\",\"message\":",
                   str(mock_log.output))
 
     @integration_test()
@@ -161,7 +161,7 @@ class CliIntegrationPolicy(IntegrationTestCaseBase):  # pragma: no cover
         policy = "- ! user bad syntax"
         output = utils.replace_policy_from_string(self, policy, exit_code=1)
 
-        self.assertIn("422 (Unprocessable Entity) for url:", output)
+        self.assertRegex(output, r".*422 \(Unprocessable (Entity|Content)\) for url:.*")
 
     @integration_test()
     def test_https_load_policy_doesnt_break_if_no_created_roles(self):


### PR DESCRIPTION
…ontent

### Desired Outcome

This PR solves current problem in failing pipeline. The cause of failures is wrong error message for code 422 which is Unprocessable Content rather than Unprocessable Entity. However in integration tests the message stays the same so I propose accepting either of these two messages.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
